### PR TITLE
Add Spring Boot OOP demo

### DIFF
--- a/demo-springboot-oop/README.md
+++ b/demo-springboot-oop/README.md
@@ -1,0 +1,57 @@
+# demo-springboot-oop
+
+Minimal Spring Boot project used to demonstrate Object-Oriented Programming concepts.
+
+## Build
+
+```bash
+mvn clean package
+```
+
+## Run
+
+```bash
+java -jar target/demo-springboot-oop-0.0.1-SNAPSHOT.jar
+```
+
+## Examples
+
+Create a product:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"name":"Book","price":9.99}' \
+    http://localhost:8080/api/products
+```
+
+Get all products:
+
+```bash
+curl http://localhost:8080/api/products
+```
+
+Actuator health:
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+OpenAI chat (will respond with placeholder unless `OPENAI_API_KEY` is set):
+
+```bash
+curl http://localhost:8080/api/ia/chat?prompt=Hello
+```
+
+Sentiment analysis:
+
+```bash
+curl http://localhost:8080/api/ia/sentiment?text=I%20love%20this
+```
+
+## Bean scopes
+* **GreetingService** - singleton (one instance for entire app)
+* **TaskBean** - prototype (new instance each request to context)
+* **RequestInfoBean** - request scope (new per HTTP request)
+* **CartBean** - session scope (stored in HTTP session)
+
+Look in the console logs for each bean's hash code to see the scope in action.

--- a/demo-springboot-oop/pom.xml
+++ b/demo-springboot-oop/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>demo-springboot-oop</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>demo-springboot-oop</name>
+    <description>Demo Spring Boot OOP Project</description>
+    <properties>
+        <java.version>17</java.version>
+        <spring-boot.version>3.1.0</spring-boot.version>
+    </properties>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>${spring-boot.version}</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.theokanning.openai</groupId>
+      <artifactId>openai-java</artifactId>
+      <version>0.18.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.demo.DemoSpringbootOopApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/demo-springboot-oop/src/main/java/com/example/demo/DemoSpringbootOopApplication.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/DemoSpringbootOopApplication.java
@@ -1,0 +1,15 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Main application class.
+ */
+@SpringBootApplication
+public class DemoSpringbootOopApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemoSpringbootOopApplication.class, args);
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/bean/CartBean.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/bean/CartBean.java
@@ -1,0 +1,20 @@
+package com.example.demo.bean;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Session scoped bean.
+ */
+@Component
+@Scope(value = WebApplicationContext.SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@Slf4j
+public class CartBean {
+
+    public CartBean() {
+        log.info("CartBean created: {}", this.hashCode());
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/bean/GreetingService.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/bean/GreetingService.java
@@ -1,0 +1,26 @@
+package com.example.demo.bean;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Singleton scoped greeting service.
+ */
+@Service
+@Slf4j
+public class GreetingService {
+
+    public GreetingService() {
+        log.info("GreetingService created: {}", this.hashCode());
+    }
+
+    @PostConstruct
+    public void init() {
+        log.info("GreetingService initialized");
+    }
+
+    public String greet(String name) {
+        return "Hello " + name;
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/bean/RequestInfoBean.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/bean/RequestInfoBean.java
@@ -1,0 +1,20 @@
+package com.example.demo.bean;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Request scoped bean.
+ */
+@Component
+@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@Slf4j
+public class RequestInfoBean {
+
+    public RequestInfoBean() {
+        log.info("RequestInfoBean created: {}", this.hashCode());
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/bean/TaskBean.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/bean/TaskBean.java
@@ -1,0 +1,18 @@
+package com.example.demo.bean;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * Prototype scoped bean.
+ */
+@Component
+@Scope("prototype")
+@Slf4j
+public class TaskBean {
+
+    public TaskBean() {
+        log.info("TaskBean created: {}", this.hashCode());
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/controller/IaController.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/controller/IaController.java
@@ -1,0 +1,31 @@
+package com.example.demo.controller;
+
+import com.example.demo.service.OpenAiClient;
+import com.example.demo.service.SentimentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller exposing simple IA endpoints.
+ */
+@RestController
+@RequestMapping("/api/ia")
+@RequiredArgsConstructor
+public class IaController {
+
+    private final OpenAiClient openAiClient;
+    private final SentimentService sentimentService;
+
+    @GetMapping("/chat")
+    public String chat(@RequestParam String prompt) {
+        return openAiClient.chat(prompt);
+    }
+
+    @GetMapping("/sentiment")
+    public String sentiment(@RequestParam String text) {
+        return sentimentService.analyze(text);
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/controller/ProductController.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/controller/ProductController.java
@@ -1,0 +1,37 @@
+package com.example.demo.controller;
+
+import com.example.demo.entity.Product;
+import com.example.demo.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controller for product operations.
+ */
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService service;
+
+    @GetMapping
+    public List<Product> all() {
+        return service.findAll();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Product create(@RequestBody Product product) {
+        return service.save(product);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        service.delete(id);
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/entity/Product.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/entity/Product.java
@@ -1,0 +1,20 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Data;
+
+/**
+ * Simple product entity.
+ */
+@Entity
+@Data
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private double price;
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/repository/ProductRepository.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository interface for Product CRUD operations.
+ */
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/service/OpenAiClient.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/service/OpenAiClient.java
@@ -1,0 +1,27 @@
+package com.example.demo.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Minimal OpenAI client wrapper used for demo purposes.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OpenAiClient {
+
+    @Value("${OPENAI_API_KEY:}")
+    private String apiKey;
+
+    public String chat(String prompt) {
+        if (apiKey == null || apiKey.isBlank()) {
+            return "OpenAI disabled (demo)";
+        }
+        // In a real implementation you would call OpenAI here
+        log.info("Would call OpenAI with prompt: {}", prompt);
+        return "OpenAI response placeholder";
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/service/ProductService.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/service/ProductService.java
@@ -1,0 +1,30 @@
+package com.example.demo.service;
+
+import com.example.demo.entity.Product;
+import com.example.demo.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Service layer for products.
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository repository;
+
+    public List<Product> findAll() {
+        return repository.findAll();
+    }
+
+    public Product save(Product product) {
+        return repository.save(product);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/service/SentimentService.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/service/SentimentService.java
@@ -1,0 +1,15 @@
+package com.example.demo.service;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Dummy sentiment analysis service.
+ */
+@Service
+public class SentimentService {
+
+    public String analyze(String text) {
+        // Always return POSITIVE for demo
+        return "POSITIVE";
+    }
+}

--- a/demo-springboot-oop/src/main/resources/application.properties
+++ b/demo-springboot-oop/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+server.port=8080
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Spring JPA
+spring.jpa.hibernate.ddl-auto=update
+
+# Actuator endpoints
+management.endpoints.web.exposure.include=health,metrics,info,env,beans
+
+# Placeholder for profiles
+spring.profiles.active=@activatedProperties@
+
+# OpenAI configuration
+OPENAI_API_KEY=


### PR DESCRIPTION
## Summary
- add demo-springboot-oop Spring Boot project
- implement Product CRUD and simple IA endpoints
- show bean scopes via logging
- document build and usage

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `apt-get install -y tree`
- `mvn -q -DskipTests package` *(fails: Could not transfer dependencies - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687316b17b0c8333b9b492b56c41d68e