### PR TITLE
Integrate Anthropic client with interface

### DIFF
--- a/demo-springboot-oop/README.md
+++ b/demo-springboot-oop/README.md
@@ -36,7 +36,7 @@ Actuator health:
 curl http://localhost:8080/actuator/health
 ```
 
-OpenAI chat (will respond with placeholder unless `OPENAI_API_KEY` is set):
+Anthropic chat (will respond with placeholder unless `ANTHROPIC_API_KEY` is set):
 
 ```bash
 curl http://localhost:8080/api/ia/chat?prompt=Hello

--- a/demo-springboot-oop/pom.xml
+++ b/demo-springboot-oop/pom.xml
@@ -45,6 +45,11 @@
         <version>0.18.2</version>
     </dependency>
     <dependency>
+        <groupId>com.anthropic</groupId>
+        <artifactId>anthropic-java</artifactId>
+        <version>2.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/demo-springboot-oop/src/main/java/com/example/demo/controller/IaController.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/controller/IaController.java
@@ -1,6 +1,6 @@
 package com.example.demo.controller;
 
-import com.example.demo.service.OpenAiClient;
+import com.example.demo.service.AiClient;
 import com.example.demo.service.SentimentService;
 import lombok.RequiredArgsConstructor;
 import java.util.Map;
@@ -19,17 +19,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class IaController {
 
-    private final OpenAiClient openAiClient;
+    private final AiClient aiClient;
     private final SentimentService sentimentService;
 
     @GetMapping("/chat")
     public ResponseEntity<Map<String, String>> chat(@RequestParam String prompt) {
         try {
-            String result = openAiClient.chat(prompt);
+            String result = aiClient.chat(prompt);
             return ResponseEntity.ok(Map.of("response", result));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(Map.of("error", "Could not contact OpenAI: " + e.getMessage()));
+                    .body(Map.of("error", "Could not contact AI service: " + e.getMessage()));
         }
     }
 

--- a/demo-springboot-oop/src/main/java/com/example/demo/service/AiClient.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/service/AiClient.java
@@ -1,0 +1,11 @@
+package com.example.demo.service;
+
+/**
+ * Generic AI chat client interface.
+ */
+public interface AiClient {
+    /**
+     * Send a prompt and get the AI response.
+     */
+    String chat(String prompt);
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/service/AnthropicClient.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/service/AnthropicClient.java
@@ -1,0 +1,36 @@
+package com.example.demo.service;
+
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+import com.anthropic.models.messages.Message;
+import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.Model;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+/**
+ * Anthropic Claude client implementation.
+ */
+@Service
+@Primary
+public class AnthropicClient implements AiClient {
+
+    private final com.anthropic.client.AnthropicClient client;
+
+    public AnthropicClient(@Value("${ANTHROPIC_API_KEY}") String apiKey) {
+        this.client = AnthropicOkHttpClient.builder()
+                .apiKey(apiKey)
+                .build();
+    }
+
+    @Override
+    public String chat(String prompt) {
+        MessageCreateParams params = MessageCreateParams.builder()
+                .model(Model.CLAUDE_3_7_SONNET_LATEST)
+                .addUserMessage(prompt)
+                .build();
+        Message message = client.messages().create(params);
+        return message.getContent();
+    }
+}

--- a/demo-springboot-oop/src/main/java/com/example/demo/service/OpenAiClient.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/service/OpenAiClient.java
@@ -4,6 +4,7 @@ import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.theokanning.openai.completion.chat.ChatCompletionResult;
 import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.service.OpenAiService;
+import com.example.demo.service.AiClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +15,7 @@ import java.util.List;
  * Minimal OpenAI client wrapper used for demo purposes.
  */
 @Service
-public class OpenAiClient {
+public class OpenAiClient implements AiClient {
 
     @Value("${OPENAI_API_KEY}")
     private String apiKey;

--- a/demo-springboot-oop/src/main/resources/application.properties
+++ b/demo-springboot-oop/src/main/resources/application.properties
@@ -15,3 +15,4 @@ spring.profiles.active=@activatedProperties@
 
 # OpenAI configuration
 OPENAI_API_KEY=
+ANTHROPIC_API_KEY=


### PR DESCRIPTION
## Summary
- add `AiClient` interface for chat services
- implement new `AnthropicClient` using anthropic-java
- update `OpenAiClient` to implement `AiClient`
- refactor `IaController` to depend on `AiClient`
- add anthropic dependency and property
- document anthropic chat endpoint in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68733c04ca648333bcce639c6c8598b7