### PR TITLE
Refactor chat endpoint into service layer

### DIFF
--- a/demo-springboot-oop/src/main/java/com/example/demo/client/OpenAiClient.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/client/OpenAiClient.java
@@ -1,11 +1,11 @@
-package com.example.demo.service;
+package com.example.demo.client;
 
 import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.theokanning.openai.completion.chat.ChatCompletionResult;
 import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.service.OpenAiService;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.List;
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * Minimal OpenAI client wrapper used for demo purposes.
  */
-@Service
+@Component
 public class OpenAiClient {
 
     @Value("${OPENAI_API_KEY}")

--- a/demo-springboot-oop/src/main/java/com/example/demo/controller/IaController.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/controller/IaController.java
@@ -1,6 +1,6 @@
 package com.example.demo.controller;
 
-import com.example.demo.service.OpenAiClient;
+import com.example.demo.service.ChatService;
 import com.example.demo.service.SentimentService;
 import lombok.RequiredArgsConstructor;
 import java.util.Map;
@@ -19,13 +19,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class IaController {
 
-    private final OpenAiClient openAiClient;
+    private final ChatService chatService;
     private final SentimentService sentimentService;
 
     @GetMapping("/chat")
     public ResponseEntity<Map<String, String>> chat(@RequestParam String prompt) {
         try {
-            String result = openAiClient.chat(prompt);
+            String result = chatService.chat(prompt);
             return ResponseEntity.ok(Map.of("response", result));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/demo-springboot-oop/src/main/java/com/example/demo/service/ChatService.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/service/ChatService.java
@@ -1,0 +1,25 @@
+package com.example.demo.service;
+
+import com.example.demo.client.OpenAiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service layer for chat operations using OpenAI.
+ */
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final OpenAiClient openAiClient;
+
+    /**
+     * Send a chat prompt to OpenAI and return the response text.
+     *
+     * @param prompt user prompt
+     * @return response from OpenAI
+     */
+    public String chat(String prompt) {
+        return openAiClient.chat(prompt);
+    }
+}


### PR DESCRIPTION
## Summary
- move `OpenAiClient` to a new `client` package
- implement `ChatService` that delegates to `OpenAiClient`
- update `IaController` to use `ChatService`

## Testing
- `mvn -q -DskipTests=false test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687344d5da80833380f1a6ead92a2c21