### PR TITLE
Add OpenAI-based SentimentService

### DIFF
--- a/demo-springboot-oop/src/main/java/com/example/demo/service/SentimentService.java
+++ b/demo-springboot-oop/src/main/java/com/example/demo/service/SentimentService.java
@@ -1,15 +1,40 @@
 package com.example.demo.service;
 
+import com.example.demo.client.OpenAiClient;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 /**
- * Dummy sentiment analysis service.
+ * Service for analyzing the sentiment of a text using OpenAI.
  */
 @Service
+@RequiredArgsConstructor
 public class SentimentService {
 
+    private final OpenAiClient openAiClient;
+
+    /**
+     * Call OpenAI to classify the sentiment of the text.
+     *
+     * @param text user text to analyze
+     * @return POSITIVE, NEGATIVE or NEUTRAL
+     */
     public String analyze(String text) {
-        // Always return POSITIVE for demo
-        return "POSITIVE";
+        String systemPrompt = "You are a sentiment analysis assistant. "
+                + "Classify the user text as POSITIVE, NEGATIVE or NEUTRAL. "
+                + "Do not add anything else.";
+        String userPrompt = systemPrompt + "\n\nText: \"" + text + "\"";
+
+        String response = openAiClient.chat(userPrompt);
+        String normalized = response.strip()
+                .toUpperCase()
+                .replaceAll("[^A-Z]", "");
+        if (normalized.contains("POSITIVE")) {
+            return "POSITIVE";
+        } else if (normalized.contains("NEGATIVE")) {
+            return "NEGATIVE";
+        } else {
+            return "NEUTRAL";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement real `SentimentService` that calls `OpenAiClient`

## Testing
- `mvn -q package` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68734715b42483339165aaebf714719d